### PR TITLE
Improve build failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - ps: gitversion /l console /output buildserver
   - ps: |
       .\restore.ps1
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)}
+      if ($LastExitCode -ne 0) {$host.SetShouldExit($LastExitCode)}
 
   # Setup GIT
   - git config --global user.email %GithubEmail%
@@ -36,7 +36,7 @@ build_script:
   - ps: |
       $ErrorActionPreference = 'Stop';
       .\generateDocs.ps1
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)}
+      if ($LastExitCode -ne 0) {$host.SetShouldExit($LastExitCode)}
   - 7z a -r %Artefact_Output_Dir%\docs.zip %APPVEYOR_BUILD_FOLDER%\docs-generated\_book
 
 after_build:
@@ -46,7 +46,7 @@ after_build:
 test_script:
   - ps: |
       .\runTests.ps1
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)}
+      if ($LastExitCode -ne 0) {$host.SetShouldExit($LastExitCode)}
 
 deploy_script:
   - ps: |
@@ -58,4 +58,4 @@ deploy_script:
         Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:GithubAccessTokenTeamUnic):x-oauth-basic@github.com`n";
         .\pushDocs.ps1 $env:APPVEYOR_BUILD_FOLDER docs-generated\_book https://github.com/unic/$($env:RepoName).git
       }
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)}
+      if ($LastExitCode -ne 0) {$host.SetShouldExit($LastExitCode)}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,9 @@ after_build:
   - cmd: appveyor PushArtifact %Artefact_Output_Dir%\docs.zip
 
 test_script:
-  - ps: .\runTests.ps1
+  - ps: |
+      .\runTests.ps1
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)}
 
 deploy_script:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,9 @@ environment:
 install:
   - choco install gitversion.portable -y
   - ps: gitversion /l console /output buildserver
-  - ps: .\restore.ps1
+  - ps: |
+      .\restore.ps1
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)}
 
   # Setup GIT
   - git config --global user.email %GithubEmail%
@@ -34,6 +36,7 @@ build_script:
   - ps: |
       $ErrorActionPreference = 'Stop';
       .\generateDocs.ps1
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)}
   - 7z a -r %Artefact_Output_Dir%\docs.zip %APPVEYOR_BUILD_FOLDER%\docs-generated\_book
 
 after_build:
@@ -53,3 +56,4 @@ deploy_script:
         Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:GithubAccessTokenTeamUnic):x-oauth-basic@github.com`n";
         .\pushDocs.ps1 $env:APPVEYOR_BUILD_FOLDER docs-generated\_book https://github.com/unic/$($env:RepoName).git
       }
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ assembly_info:
   patch: false
 
 build_script:
-  - cmd: nuget pack %Nuspec_File% -version "%GitVersion_NuGetVersionV2%" -OutputDirectory %Artefact_Output_Dir%
+  - cmd: nuget pack %Nuspec_File% -version "%GitVersion_NuGetVersionV2%" -OutputDirectory %Artefact_Output_Dir% -NoPackageAnalysis
   - ps: |
       $ErrorActionPreference = 'Stop';
       .\generateDocs.ps1

--- a/docs/book.json
+++ b/docs/book.json
@@ -1,7 +1,7 @@
 {
     "gitbook": "3.2.3",
     "plugins": [
-        "theme-unic@git+https://github.com/unic/gitbook-plugin-theme-unic.git"
+        "theme-unic@git+https://github.com/unic/gitbook-plugin-theme-unicxx.git"
     ],
     "links": {
         "sharing": {

--- a/docs/book.json
+++ b/docs/book.json
@@ -1,7 +1,7 @@
 {
     "gitbook": "3.2.3",
     "plugins": [
-        "theme-unic@git+https://github.com/unic/gitbook-plugin-theme-unicxx.git"
+        "theme-unic@git+https://github.com/unic/gitbook-plugin-theme-unic.git"
     ],
     "links": {
         "sharing": {


### PR DESCRIPTION
currently, with some powershell based exeption, AppVeyor will not fail builds. this should improve build status reporting a lot. Tested it with a failing gitbook installation here: https://ci.appveyor.com/project/team-unic/bob-lofty/build/5.1.1-improve-build-failure.3.build.40